### PR TITLE
XTG-40 Pawn promotion

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/lodash": "4.14.178",
     "chess.js": "0.12.0",
     "lodash": "4.17.21",
-    "phaser": "3.55.2"
+    "phaser": "3.55.2",
+    "phaser3-rex-plugins": "1.1.66"
   }
 }

--- a/src/game/ChessBoard.ts
+++ b/src/game/ChessBoard.ts
@@ -1,7 +1,7 @@
 import { Square } from 'chess.js';
 import { isNaN, toNumber, parseInt } from 'lodash';
-import ChessPiece, { Piece } from "./Piece";
-import { chessColumns, ONE, SQUARES_IN_WIDTH, TWO, ZERO } from "./utils/consts";
+import ChessPiece from "./Piece";
+import { BLACK_SQUARE_COLOR, chessColumns, ONE, Piece, SQUARES_IN_WIDTH, TWO, WHITE_SQUARE_COLOR, ZERO } from "./utils/consts";
 
 interface chessBoardSquare {
   positionNumber: number;
@@ -13,9 +13,9 @@ interface chessBoardSquare {
 export default class ChessBoard extends Phaser.GameObjects.Container {
   private fen: string = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
   private board: chessBoardSquare[] = [];
-  private blackColor = 0x6666ff;
+  private blackColor = BLACK_SQUARE_COLOR;
   private blackColorHex = '#6666FF';
-  private whiteColor = 0xE8E8FF;
+  private whiteColor = WHITE_SQUARE_COLOR;
   private whiteColorHex = '#E8E8FF';
   private fontSize = '15px';
   private possibleMovementCircleColor = 0x0A3E5C;
@@ -101,8 +101,8 @@ export default class ChessBoard extends Phaser.GameObjects.Container {
     // LOAD STARTING PIECES
     this.loadPositionFromFen(startingFen || this.fen);
 
-    const newXposition = (scene.game.canvas.width / TWO) - (this.width / TWO);
-    const newYposition = (scene.game.canvas.height / TWO) - (this.height / TWO);
+    const newXposition = (scene.game.canvas.width - this.width ) / TWO;
+    const newYposition = (scene.game.canvas.height - this.height) / TWO;
     this.setPosition(newXposition, newYposition);
     // console.log(this.board.map(({
     //   positionName,

--- a/src/game/Piece.ts
+++ b/src/game/Piece.ts
@@ -1,17 +1,5 @@
 import { Square } from "chess.js";
-
-export enum Piece {
-  None = 0,
-  King = 1,
-  Pawn = 2,
-  Knight = 3,
-  Bishop = 4,
-  Rook = 5,
-  Queen = 6,
-
-  White = 8,
-  Black = 16,
-}
+import { Piece } from "./utils/consts";
 
 export default class ChessPiece extends Phaser.GameObjects.Image {
 
@@ -93,6 +81,11 @@ export default class ChessPiece extends Phaser.GameObjects.Image {
 
   static pieceType (piece: Piece) {
     return piece & this.typeMask;
+  }
+
+  getColour() {
+    const isPieceColorBlack = ChessPiece.isColour(this.chessPiece, Piece.Black);
+    return (isPieceColorBlack) ? Piece.Black : Piece.White;
   }
 
   getChessPiece() {

--- a/src/game/Piece.ts
+++ b/src/game/Piece.ts
@@ -11,7 +11,12 @@ export default class ChessPiece extends Phaser.GameObjects.Image {
   private chessPiece: number;
   private positionInBoard: Square;
 
-  constructor(piece: number, positionInBoard: Square, squareParent: Phaser.GameObjects.Rectangle, scene: Phaser.Scene) {
+  constructor(
+    piece: number,
+    positionInBoard: Square,
+    squareParent: Phaser.GameObjects.Rectangle,
+    scene: Phaser.Scene,
+  ) {
     const isPieceColorBlack = ChessPiece.isColour(piece, Piece.Black);
     let mutableImageName = '';
     if (isPieceColorBlack) {

--- a/src/game/interfaces/index.ts
+++ b/src/game/interfaces/index.ts
@@ -1,10 +1,21 @@
+import { Square } from "chess.js";
 import { Piece } from "../utils/consts";
 
-export interface PromotionSeed {
-  rectangle: Phaser.GameObjects.Rectangle,
-  pieceColor: Piece.Black | Piece.White,
+export interface PromotionParams {
+  rectangle: Phaser.GameObjects.Rectangle;
+  pieceColor: Piece.Black | Piece.White;
+  origin: Square;
+  target: Square;
   offset?: {
-    x: number,
-    y: number,
+    x: number;
+    y: number;
   }
+}
+
+export interface PromotionOptionSelected {
+  fullName: string;
+  pieceName: string;
+  origin: Square;
+  target: Square;
+  pieceColor: Piece.Black | Piece.White,
 }

--- a/src/game/interfaces/index.ts
+++ b/src/game/interfaces/index.ts
@@ -1,0 +1,10 @@
+import { Piece } from "../utils/consts";
+
+export interface PromotionSeed {
+  rectangle: Phaser.GameObjects.Rectangle,
+  pieceColor: Piece.Black | Piece.White,
+  offset?: {
+    x: number,
+    y: number,
+  }
+}

--- a/src/game/utils/SceneKeys.ts
+++ b/src/game/utils/SceneKeys.ts
@@ -1,6 +1,7 @@
 enum SceneKeys {
 	Preloader = 'preloader',
-	MainBoard = 'game'
+	MainBoard = 'game',
+	Promotion = 'promotion',
 };
 
 export default SceneKeys;

--- a/src/game/utils/consts.ts
+++ b/src/game/utils/consts.ts
@@ -1,5 +1,6 @@
 // GENERAL GAME
 export const GAME_BG_COLOR = 0x848D9A;
+export const TEXT_COLOR = '#252D38';
 
 // EXPLICIT NUMBERS
 export const ZERO = 0;
@@ -13,3 +14,19 @@ export const POSSIBLE_MOVE_BORDER_LINE_WIDTH = 4;
 export const POSSIBLE_MOVE_BORDER_COLOR = 0xFFFEEB;
 export const SQUARE_TO_MOVE_COLOR = 0xCBF559;
 export const chessColumns = 'abcdefgh';
+
+// CHESS PIECE
+export enum Piece {
+  None = 0,
+  King = 1,
+  Pawn = 2,
+  Knight = 3,
+  Bishop = 4,
+  Rook = 5,
+  Queen = 6,
+
+  White = 8,
+  Black = 16,
+}
+export const BLACK_SQUARE_COLOR = 0x6666ff;
+export const WHITE_SQUARE_COLOR = 0xE8E8FF;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,7 @@ import { GAME_BG_COLOR } from './game/utils/consts';
 import SceneKeys from './game/utils/SceneKeys';
 import MainBoardScene from './scenes/MainBoard';
 import Preloader from './scenes/Preloader';
-
-
+import PromotionScene from './scenes/Promotion';
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -28,9 +27,11 @@ const config: Phaser.Types.Core.GameConfig = {
 
 const chessGame = new Phaser.Game(config);
 
-chessGame.scene.add(SceneKeys.Preloader, Preloader)
-chessGame.scene.add(SceneKeys.MainBoard, MainBoardScene)
+// SCENES
+chessGame.scene.add(SceneKeys.Preloader, Preloader);
+chessGame.scene.add(SceneKeys.MainBoard, MainBoardScene);
+chessGame.scene.add(SceneKeys.Promotion, PromotionScene);
 
-chessGame.scene.start(SceneKeys.Preloader)
+chessGame.scene.start(SceneKeys.Preloader);
 
 export default chessGame;

--- a/src/scenes/MainBoard.ts
+++ b/src/scenes/MainBoard.ts
@@ -2,6 +2,7 @@ import { Chess, ChessInstance, Square } from 'chess.js';
 import ChessBoard from "../game/ChessBoard";
 import ChessPiece from '../game/Piece';
 import { ONE, POSSIBLE_MOVE_BORDER_COLOR, POSSIBLE_MOVE_BORDER_LINE_WIDTH, SQUARE_TO_MOVE_COLOR, THREE, TWO, ZERO } from '../game/utils/consts';
+import SceneKeys from '../game/utils/SceneKeys';
 
 export default class MainBoardScene extends Phaser.Scene {
   private chessBoard!: ChessBoard;
@@ -12,6 +13,12 @@ export default class MainBoardScene extends Phaser.Scene {
   preload() {}
 
   create() {
+    // Promotion for white
+    // this.chessBoard = new ChessBoard(this, 0, 0,'rnbq2nr/ppppkPpp/3b4/4p3/8/8/PPPP1PPP/RNBQKBNR w KQ - 1 5');
+    // this.chessGame = new Chess('rnbq2nr/ppppkPpp/3b4/4p3/8/8/PPPP1PPP/RNBQKBNR w KQ - 1 5');
+    // Promotion for black
+    // this.chessBoard = new ChessBoard(this, 0, 0,'rnbq2nr/ppppkPpp/3b4/8/8/3B3N/PPPPKpPP/RNBQ3R b - - 1 8');
+    // this.chessGame = new Chess('rnbq2nr/ppppkPpp/3b4/8/8/3B3N/PPPPKpPP/RNBQ3R b - - 1 8');
     this.chessBoard = new ChessBoard(this, 0, 0);
     this.chessGame = new Chess(this.chessBoard.getFen());
 
@@ -133,11 +140,6 @@ export default class MainBoardScene extends Phaser.Scene {
         square.rectangle.setStrokeStyle(ZERO);
       }
 
-      // Hay que revisar esto mejor
-      // if ((dragablePiece.getPositionInBoard() === square.positionName)) {
-      //   square.piece = undefined;
-      // }
-
 
       if ((rectangle.x === square.rectangle.x) && (rectangle.y === square.rectangle.y)) {
         let mutableFinalMove: string = '';
@@ -145,6 +147,19 @@ export default class MainBoardScene extends Phaser.Scene {
           const mutableMoves: string[] = sansMoves.filter((move) => move.includes(square.positionName));
           if (mutableMoves.length === ONE) {
             mutableFinalMove = mutableMoves.pop()!;
+          } else {
+            // Is it a promotion?
+            this.game.scene.pause(SceneKeys.MainBoard);
+            this.game.scene.start(
+              SceneKeys.Promotion,
+              {
+                rectangle: square.rectangle,
+                pieceColor: dragablePiece.getColour(),
+                offset: {
+                  x: (this.game.canvas.width - this.chessBoard.width) /TWO,
+                  y: (this.game.canvas.height - this.chessBoard.height) /TWO,
+                }
+              });
           }
 
           if (square.piece) {
@@ -226,7 +241,7 @@ export default class MainBoardScene extends Phaser.Scene {
         this.chessBoard.setFen(this.chessGame.fen());
         // console.log(`The move was: ${mutableFinalMove}`);
         // console.log(`The chessBoard FEN: ${this.chessBoard.getFen()}`);
-        // console.log(`The chess lib FEN: ${this.chessGame.fen()}`);
+        console.log(`The chess lib FEN: ${this.chessGame.fen()}`);
         // console.log(`Are they the same?: ${this.chessGame.fen() === this.chessGame.fen()}`);
       }
 

--- a/src/scenes/MainBoard.ts
+++ b/src/scenes/MainBoard.ts
@@ -15,10 +15,10 @@ export default class MainBoardScene extends Phaser.Scene {
 
   create() {
     // Promotion
-    this.chessBoard = new ChessBoard(this, 0, 0,'rnbq2nr/ppppkPpp/3b4/8/8/3B3N/PPPPKpPP/RNBQ3R b - - 1 8');
-    this.chessGame = new Chess('rnbq2nr/ppppkPpp/3b4/8/8/3B3N/PPPPKpPP/RNBQ3R b - - 1 8');
-    // this.chessBoard = new ChessBoard(this, 0, 0);
-    // this.chessGame = new Chess(this.chessBoard.getFen());
+    // this.chessBoard = new ChessBoard(this, 0, 0,'rnbq2nr/ppppkPpp/3b4/8/8/3B3N/PPPPKpPP/RNBQ3R b - - 1 8');
+    // this.chessGame = new Chess('rnbq2nr/ppppkPpp/3b4/8/8/3B3N/PPPPKpPP/RNBQ3R b - - 1 8');
+    this.chessBoard = new ChessBoard(this, 0, 0);
+    this.chessGame = new Chess(this.chessBoard.getFen());
 
     //  The pointer has to move 16 pixels before it's considered as a drag
     this.input.dragDistanceThreshold = 16;

--- a/src/scenes/Promotion.ts
+++ b/src/scenes/Promotion.ts
@@ -113,7 +113,7 @@ export default class PromotionScene extends Phaser.Scene {
       // promotionPiece.setDataEnabled();
       promotionPiece.setData({
         fullName: `${pieceColorName}${pieceName}`,
-        pieceName,
+        pieceName: (pieceName === 'knight') ? 'nknight' : pieceName,
       })
       promotionPiece.setScale(0.2)
       promotionPiece.setInteractive();

--- a/src/scenes/Promotion.ts
+++ b/src/scenes/Promotion.ts
@@ -1,0 +1,109 @@
+import { PromotionSeed } from "../game/interfaces";
+import RoundRectanglePlugin from 'phaser3-rex-plugins/plugins/roundrectangle';
+import { ONE, Piece, TEXT_COLOR, TWO, ZERO } from "../game/utils/consts";
+
+export default class PromotionScene extends Phaser.Scene {
+  private pieceColor: Piece.Black | Piece.White = Piece.Black;
+
+  init(promotionSeed: PromotionSeed) {
+    
+    const { rectangle: { x, y, width, height }, pieceColor, offset } = promotionSeed;
+    const squareColor = 0xF7F7FF;
+    const piecesToShow = 4;
+    const piecesOptionsHeight =  (width * piecesToShow);
+    const sizeInPercentage = 0.08;
+    const closeButtonHeight = piecesOptionsHeight * sizeInPercentage;
+    const offsetX = (offset?.x??ZERO);
+    const offsetY = (offset?.y??ZERO);
+    const moveUpOptions = 3;
+    const roundedBorderSize = 10;
+
+    // PIECE OPTIONS
+    const xPosition = (pieceColor === Piece.White) ? x + offsetX : x + offsetX;
+    const yPosition = (pieceColor === Piece.White) ? y + offsetY : y - (moveUpOptions * height) + offsetY;
+    const piecesOptionsButton = new RoundRectanglePlugin(
+      this,
+      xPosition,
+      yPosition,
+      width,
+      piecesOptionsHeight,
+      (pieceColor === Piece.White) ?
+        {
+          tl: roundedBorderSize,
+          tr: roundedBorderSize,
+          bl: ZERO,
+          br: ZERO,
+        } :
+        {
+          tl: ZERO,
+          tr: ZERO,
+          bl: roundedBorderSize,
+          br: roundedBorderSize,
+        }
+      ,
+      squareColor,
+    );
+    piecesOptionsButton.setOrigin(ZERO, ZERO);
+    this.add.existing(piecesOptionsButton);
+
+    // CLOSE BUTTON
+    const closeXPosition = xPosition;
+    const closeYPosition = (pieceColor === Piece.White) ? yPosition + piecesOptionsButton.height : piecesOptionsButton.y - closeButtonHeight;
+    const closeButtonColor = 0xDCDCE3;
+    const closeButton = new RoundRectanglePlugin(
+      this,
+      closeXPosition,
+      closeYPosition,
+      width,
+      closeButtonHeight,
+      (pieceColor === Piece.White) ?
+        {
+          tl: ZERO,
+          tr: ZERO,
+          bl: roundedBorderSize,
+          br: roundedBorderSize,
+        } :
+        {
+          tl: roundedBorderSize,
+          tr: roundedBorderSize,
+          bl: ZERO,
+          br: ZERO,
+        }
+      ,
+      closeButtonColor,
+    );
+    closeButton.setOrigin(ZERO, ZERO);
+    this.add.existing(closeButton);
+
+    // X CLOSE "BUTTON"
+    const originAt = 0.5;
+    this.add.text(
+      closeButton.x + (closeButton.width / TWO), 
+      closeButton.y + (closeButton.height / TWO), 
+      'x', 
+      { fontFamily: 'Helvetica', fontSize: '.8rem', color: TEXT_COLOR },
+    )
+    .setOrigin(originAt, originAt);
+
+    this.pieceColor = pieceColor;
+    const pieceColorName = (this.pieceColor === Piece.Black) ? 'black_' : 'white_' ;
+    const promotionPiecesNames = [
+      'queen',
+      'knight',
+      'rook',
+      'bishop',
+    ];
+    promotionPiecesNames.forEach((pieceName, i) => {
+      const squareCenter = width / 2;
+      const xPos = piecesOptionsButton.x;
+      const yPos = piecesOptionsButton.y * (i + ONE);
+      const promotionPiece = this.add.image(xPos + squareCenter, yPos + squareCenter, 'chess-pieces-atlas', `${pieceColorName}${pieceName}.png`);
+      promotionPiece.setScale(0.2)
+      promotionPiece.setInteractive();
+    });
+  }
+
+  create() {
+    
+  }
+}


### PR DESCRIPTION
In chess, **[promotio](https://en.wikipedia.org/wiki/Promotion_(chess))**n is the replacement of a pawn with a queen, rook, bishop, or knight of the same color once the pawn reaches the rank furthest from its starting position.[1] The new piece replaces the pawn on the promotion square on the same move. The choice of the new piece is not limited to pieces previously captured; thus, promotion can result in a player owning, for example, two or more queens despite starting the game with one.[2] The pawn cannot promote to a king or remain as a pawn.